### PR TITLE
Atribuir papel de QA ao destinatário

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
-  "name": "Organizacao10x",
+  "name": "organizacao10x",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "organizacao10x",
+      "workspaces": [
+        "web"
+      ],
       "dependencies": {
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.55.0",


### PR DESCRIPTION
## Resumo
Configura o projeto como um monorepo, adicionando `web` como um workspace e ajustando o nome do pacote principal. Isso permite que o diretório `web` seja tratado como um pacote local, resolvendo o problema de `web/` estar vazio e habilitando a instalação de dependências e os próximos passos de QA.

## Checklist
- [ ] Build e lint verdes localmente
- [ ] Evidências anexadas (quando aplicável) em `web/Estrutura/`
- [ ] Atualizei `Checklist_Release_Validation.txt` se for entrega de fluxo

## Testes/QA
Após o merge, rodar `npm install` para garantir que as dependências do workspace `web` sejam instaladas corretamente.

---
<a href="https://cursor.com/background-agent?bcId=bc-db073434-93d0-481f-9d71-8d7dad12ea01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db073434-93d0-481f-9d71-8d7dad12ea01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

